### PR TITLE
Xtrace Option Builder: Ensure that default tracepoints are disabled by default

### DIFF
--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -139,7 +139,7 @@ The project website pages cannot be redistributed
 		</td>
 		<td>
 			&nbsp;
-			<input disabled type="checkbox" id="disable_predefined" name="disable_predefined" value="disable_predefined" title="Disables all tracepoints that are enabled by default for applicable destinations:&#10;    - Maximal buffers:  all Level 1 and Level 2 tracepoints&#10;    - Exception buffers:  verbose GC logging tracepoints" checked">
+			<input disabled type="checkbox" id="disable_predefined" name="disable_predefined" value="disable_predefined" title="Disables all tracepoints that are enabled by default for applicable destinations:&#10;    - Maximal buffers:  all Level 1 and Level 2 tracepoints&#10;    - Exception buffers:  verbose GC logging tracepoints" checked>
 			<label data-disabled="true" for="disable_predefined" title="Disables all tracepoints that are enabled by default for applicable destinations:&#10;    - Maximal buffers:  all Level 1 and Level 2 tracepoints&#10;    - Exception buffers:  verbose GC logging tracepoints">Disable default tracepoints</label>
 		</td>
 	</tr>


### PR DESCRIPTION
In the vast majority of cases the user is only interested in the tracepoints and triggers that they are enabling in the option builder UI, and they do not need data from the tracepoints that are enabled by default. Moreover, the data generated by the default tracepoints can overwhelm the tracepoints that the user is interested in. In the worst case, when tracing to a size-limited binary trace file, the data the user is interested in can easily be pushed out and lost completely.

So default tracepoints should be disabled by default when building an option that will trace to the `maximal` or `exception` trace buffers. The default tracepoints can of course be re-enabled if desired.

This was actually always the intended behaviour, but there was a typo in the HTML that prevented it from happening - a floating `"` character. This commit simply removes that character.