### PR TITLE
Update latest release section for 0.46.0 in website

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,43 +115,31 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 </div>
 </div>
 
-<div class="w3-padding-64 w3-container w3-light-grey">
-  <div class="w3-content">
-        <div class="w3-center">
-      <h1>Eclipse OpenJ9 version 0.44.0 released</h1>
-<p>May 2024</p>
-</div>
-<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.44.0.</p>
-<p>This release supports OpenJDK 8, 11, 17, and 21. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
-<p>Updates in this release include the following:</p>
-<ul>
-  <li>Like on other operating systems, on AIX systems also, the display of warnings each time the same agent is loaded without specifying the <code>-XX:+EnableDynamicAgentLoading</code> option is now restricted to a single warning on the first load only.</li>
-  <li>XL C++ Runtime 16.1.0.7 or later is required for AIX OpenJ9 builds on OpenJDK 8.</li>
-  <li>A new option, <code>-XX:[+|-]ShowUnmountedThreadStacks</code>, is added to control the inclusion of the unmounted virtual threads in a Java core file.</li>
-  <li>For OpenJDK compatibility, OpenJ9 now supports direct use of the Java process name, full or partial, as the ID to send the <code>jcmd</code> command. The <code>jcmd</code> tool also now supports specifying <code>0</code> as a VMID to target all VMs.</li>
-  <li>Flag names that refer to the fields of <code>J9BuildFlags</code> are changed in the Direct Dump Reader (DDR) code. To reduce complexity and improve the uniformity of how the DDR code uses the flags, you must use the names that are specified in <code>j9cfg.h</code> as flag names in the plug-in code.</li>
-  <li>A new system property, <code>-Dcom.ibm.tools.attach.fileAccessUpdateTime</code>, is added to prevent automatic deletion of the Attach API control files in the <code>/tmp</code> folder.</li>
-</ul>   
-<p>To read more about these and other changes, see the <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_releases/" target="_blank">OpenJ9 user documentation</a>.</p>
-<p><b>Performance highlights include:</b></p>
-<ul>
-  <li>Improvements to JVMTI redefinition and restransformation runtime performance in Java 17 and later.</li>
-  <li>JITServer now supports Java 21.</li>
-  <li>Performance optimization due to not storing or finding heap size hints when heap is fully expanded.</li>
-  </ul>
-
-  </div>
-</div>
 
 <div class="w3-padding-64 w3-container w3-light-grey">
   <div class="w3-content">
         <div class="w3-center">
-      <h1>Eclipse OpenJ9 version 0.45.0 released</h1>
-<p>May 2024</p>
+      <h1>Eclipse OpenJ9 version 0.46.0 released</h1>
+<p>August 2024</p>
 </div>
-<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.45.0.</p>
-<p>This release supports OpenJDK version 22. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
-<p>Note: There are no additional issues or features specific to v0.45.0. All the issues or features in the v0.44.0 release are available in v0.45.0.</p>
+<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.46.0.</p>
+<p>This release supports OpenJDK 8, 11, 17, 21, and 22. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
+<p>Other updates in this release include the following:</p>
+ <ul>
+   <li>OpenSSL native cryptographic support is added for the MD5 message digest algorithm, providing improved cryptographic performance.</li>
+   <li>The OpenJ9 VM implementation supports measurement of the total memory allocation for all threads (<code>com.sun.management.ThreadMXBean.getTotalThreadAllocatedBytes()</code> API).</li>
+   <li>The JITServer AOT caching feature is enabled by default at the JITServer server. The client still needs the <code>-XX:+JITServerUseAOTCache</code> option, but it no longer relies on the presence of a shared class cache to take advantage of this feature.</li>
+   <li>A new option <code>-XX:[+|-]EnableExtendedHCR</code> is added to enable or disable the extended Hot Code Replace (HCR) capability in the VM.</li>
+   <li>A new option <code>-XX:[+|-]ShareOrphans</code> is added to enable class sharing from all class loaders, irrespective of whether the class loader implements the shared classes cache API.</li>
+   <li>A new option <code>-XdynamicHeapAdjustment</code> option is added to automatically adjust the maximum and minimum Java heap sizes such that they are within the physical memory limitations on the checkpoint and restore systems.</li>
+ </ul>   
+ <p>To read more about these and other changes, see the <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_releases/" target="_blank">OpenJ9 user documentation</a>.</p>
+ <p><b>Performance highlights include the following:</b></p>
+ <ul>
+   <li>Performance of object and array allocation sequences on X86 is improved.</li>
+   <li>Performance of array copying sequences on X86 is improved.</li>
+   <li>VarHandle performance is improved.</li>
+   </ul>
   </div>
 </div>
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/366

Updated latest release section for 0.46.0 in website. Added performance highlights.

Closes #366
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>