### PR TITLE
Update latest release section for 0.47.0 in website

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,22 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 </div>
 </div>
 
+<div class="w3-padding-64 w3-container w3-light-grey">
+  <div class="w3-content">
+        <div class="w3-center">
+      <h1>Eclipse OpenJ9 version 0.47.0 released</h1>
+<p>September 2024</p>
+</div>
+<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.47.0.</p>
+<p>This release supports OpenJDK 23. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
+<p>Other updates in this release include the following:</p>
+ <ul>
+    <li>The <code>-Xshareclasses</code> option automatically enables the <code>-XX:+ShareOrphans</code> option.</li>
+</ul>   
+  <p>To read more about these and other changes, see the <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_releases/" target="_blank">OpenJ9 user documentation</a>.</p>
+  
+  </div>
+</div>
 
 <div class="w3-padding-64 w3-container w3-light-grey">
   <div class="w3-content">


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/367

Updated latest release section for 0.47.0 in website. Clubbed it with the 0.46.1 release

Closes #367
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>