### PR TITLE
Update latest release section for 0.49.0 in website

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,25 +118,22 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 <div class="w3-padding-64 w3-container w3-light-grey">
   <div class="w3-content">
         <div class="w3-center">
-      <h1>Eclipse OpenJ9 version 0.48.0 released</h1>
-<p>November 2024</p>
+      <h1>Eclipse OpenJ9 version 0.49.0 released</h1>
+<p>February 2025</p>
 </div>
-<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.48.0.</p>
+<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.49.0.</p>
 <p>This release supports OpenJDK 8, 11, 17, 21, and 23. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
 <p>Other updates in this release include the following:</p>
  <ul>
-    <li>JDWP support on Checkpoint/Restore In Userspace (CRIU) restore is enabled. A new parameter <code>suspendOnRestore</code> for the <code>-Xrunjdwp</code> option is added to control the suspension of the target VM application on restore.</li>
-    <li>Like in OpenJDK 23, the <code>-Xshareclasses</code> option automatically enables the <code>-XX:+ShareOrphans</code> option in OpenJDK 8, 11, 17, and 21 also. This feature was added in OpenJDK 23 in the 0.47.0 release. </li>
+    <li>The shared classes cache generation number is incremented causing the VM to create new shared caches, rather than re-creating or reusing existing caches. To save space, all existing shared caches should be removed unless they are in use by an earlier release.</li>
+    <li>A new shared classes cache suboption <code>-Xshareclasses:extraStartupHints=&lt;number&gt;</code> is added to adjust the number of startup hints that can be stored in a shared cache.</li>
+    <li><code>subAllocator</code> related <code>-Xgc</code> options are added to control the compressed reference allocation.</li>
+    <li>Support for JDK Flight Recorder (JFR) in the VM is provided as a technical preview for OpenJDK 11 and later running on Linux&reg; x86 or Linux on AArch64 and the recording can be triggered with the <code>jcmd</code> tool.</li>  
 </ul>   
   <p>To read more about these and other changes, see the <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_releases/" target="_blank">OpenJ9 user documentation</a>.</p>
   <p><b>Performance highlights include the following:</b></p>
   <ul>
-    <li>Performance of <code>java.lang.System.arraycopy</code> on x86 is improved.</li>
-    <li>Performance of <code>java.util.Arrays.hashCode</code> operating on arrays of type <code>byte</code>, <code>char</code>, <code>short</code>, and <code>int</code> is improved on IBM z13&reg; or newer architecture on all platforms for OpenJDK versions 21 and 23.</li>
-    <li>Performance of <code>java.lang.Object.clone</code> operations on arrays is improved on all platforms and versions.</li>
-    <li>Accessing instance fields through methods of the Unsafe classes is improved.</li>
-    <li>Performance of code operating on static final fields of primitive types is improved.</li>
-    <li>VarHandle performance is improved for OpenJDK versions 17 and 21.</li>
+    <li>POWER11 CPU recognition and exploitation are added to achieve optimal performance on new hardware.</li>
   </ul>
   </div>
 </div>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/369

Updated latest release section for 0.49.0 in website.

Closes #369
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>