### PR TITLE
Add maxstringlength option to Xtrace Option Builder

### DIFF
--- a/tools/xtrace_option_builder.html
+++ b/tools/xtrace_option_builder.html
@@ -101,7 +101,7 @@ a.remove {
 <link rel="stylesheet" type="text/css" href="oj9_option_builder.css">
 
 <!--
-Copyright (c) 2017, 2023 IBM Corp. and others
+Copyright (c) 2017, 2025 IBM Corp. and others
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which accompanies this distribution and is available at http://eclipse.org/legal/epl-2.0 or the Apache License, Version 2.0 which accompanies this distribution and is available at https://www.apache.org/licenses/LICENSE-2.0.
 This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: GNU General Public License, version 2 with the GNU Classpath Exception [1] and GNU General Public License, version 2 with the OpenJDK Assembly Exception [2].
 [1] https://www.gnu.org/software/classpath/license.html
@@ -141,6 +141,11 @@ The project website pages cannot be redistributed
 			&nbsp;
 			<input disabled type="checkbox" id="disable_predefined" name="disable_predefined" value="disable_predefined" title="Disables all tracepoints that are enabled by default for applicable destinations:&#10;    - Maximal buffers:  all Level 1 and Level 2 tracepoints&#10;    - Exception buffers:  verbose GC logging tracepoints" checked>
 			<label data-disabled="true" for="disable_predefined" title="Disables all tracepoints that are enabled by default for applicable destinations:&#10;    - Maximal buffers:  all Level 1 and Level 2 tracepoints&#10;    - Exception buffers:  verbose GC logging tracepoints">Disable default tracepoints</label>
+		</td>
+		<td title="Maximum number of characters to capture from String objects in &quot;this&quot; references and method trace arguments / return values">
+			&nbsp;
+			<label data-disabled="true" for="max_string_length">Maximum String length: </label>
+			<input disabled type="number" id="max_string_length" min="0" max="128" value="32" size="1">
 		</td>
 	</tr>
 </table>

--- a/tools/xtrace_option_builder.js
+++ b/tools/xtrace_option_builder.js
@@ -177,6 +177,9 @@ function initialSetup() {
 	document.getElementById("button_add_trigger_tracepoint").addEventListener(  'click',  addTrigger.bind(null, 'tracepoint'));
 	document.getElementById("button_add_trigger_group").addEventListener(       'click',  addTrigger.bind(null, 'group'));
 
+	document.getElementById("max_string_length").addEventListener(              'change', processChange.bind(null, document.getElementById("max_string_length")));
+	document.getElementById("max_string_length").addEventListener(              'blur',   processChange.bind(null, document.getElementById("max_string_length")));
+
 	document.getElementById("trace_initially_disabled").addEventListener(       'change', processChange.bind(null, document.getElementById("trace_initially_disabled")));
 
 	document.getElementById("sleep_time").addEventListener(                     'change', processChange.bind(null, document.getElementById("sleep_time")));
@@ -668,6 +671,13 @@ function processChange(option) {
 			}
 		}
 	}	
+
+	// Enable the max_string_length field if an mt tracepoint is enabled
+	if (isMethodTracepointEnabledForTracing() || isAllTracepointEnabledForTracing()) {
+		enableInput(document.getElementById("max_string_length"));
+	} else {
+		disableInput(document.getElementById("max_string_length"));
+	}
 
 	// Enable the sleeptime field if a thread sleep action is selected
 	if (isThreadSleepActionSelected()) {
@@ -1783,6 +1793,12 @@ function buildAndUpdateResult() {
 		resultString += triggerString + ",";
 	}
 
+	// Maximum String length	
+	var maxStringLengthElement = document.getElementById("max_string_length");
+	if (!maxStringLengthElement.disabled && maxStringLengthElement.value != 32) {
+		resultString += "maxstringlength=" + maxStringLengthElement.value + ",";
+	}
+
 	// Add output and/or exception.output
 	var outputString = getOutputResultString();
 	if (outputString != "") {
@@ -2190,6 +2206,14 @@ function buildAndUpdateResult() {
 		errorsHtml += "ERROR: Invalid stack depth (" + stackDepthElement.value + "): must be > 0, or 0 to set no limit.<br>";
 	} else {
 		unsetErrorStyle(stackDepthElement);
+	}
+	var maxStringLengthElement = document.getElementById("max_string_length");
+	if (maxStringLengthElement.value < 0 || maxStringLengthElement.value > 128) {
+		resultIsGreen = false;
+		setErrorStyle(maxStringLengthElement);
+		errorsHtml += "ERROR: Invalid maximum string length (" + maxStringLengthElement.value + "): valid range is 0-128.<br>";
+	} else {
+		unsetErrorStyle(maxStringLengthElement);
 	}
 
 	// Add the result string in the appropriate colour


### PR DESCRIPTION
This patch adds the new `maxstringlength` option to the Xtrace Option Builder tool.

See https://github.com/eclipse-openj9/openj9/issues/16416 and the associated commits for more information.