### PR TITLE
Update latest release section for 0.51.0 in website

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,22 +118,23 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 <div class="w3-padding-64 w3-container w3-light-grey">
   <div class="w3-content">
         <div class="w3-center">
-      <h1>Eclipse OpenJ9 version 0.49.0 released</h1>
-<p>February 2025</p>
+      <h1>Eclipse OpenJ9 version 0.51.0 released</h1>
+<p>May 2025</p>
 </div>
-<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.49.0.</p>
-<p>This release supports OpenJDK 8, 11, 17, 21, and 23. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
+<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.51.0.</p>
+<p>This release supports OpenJDK 8, 11, 17, and 21. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
 <p>Other updates in this release include the following:</p>
  <ul>
-    <li>The shared classes cache generation number is incremented causing the VM to create new shared caches, rather than re-creating or reusing existing caches. To save space, all existing shared caches should be removed unless they are in use by an earlier release.</li>
-    <li>A new shared classes cache suboption <code>-Xshareclasses:extraStartupHints=&lt;number&gt;</code> is added to adjust the number of startup hints that can be stored in a shared cache.</li>
-    <li><code>subAllocator</code> related <code>-Xgc</code> options are added to control the compressed reference allocation.</li>
-    <li>Support for JDK Flight Recorder (JFR) in the VM is provided as a technical preview for OpenJDK 11 and later running on Linux&reg; x86 or Linux on AArch64 and the recording can be triggered with the <code>jcmd</code> tool.</li>  
+    <li>Ubuntu 20.04 is out of support. Ubuntu 22.04 is the new minimum operating system level.</li>
+    <li>A new parameter <code>maxstringlength</code> is added to the <code>-Xtrace</code> option to specify the length of the string arguments and return values of a method that are now printed in a trace output in addition to the addresses.</li>
+    <li>XL C++ Runtime 16.1.0.10 or later is required for AIX OpenJ9 builds.</li>
+    <li>Support for JDK Flight Recorder (JFR) in the VM is provided as a technical preview for OpenJDK 11 and later running on all platforms.</li>
 </ul>   
   <p>To read more about these and other changes, see the <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_releases/" target="_blank">OpenJ9 user documentation</a>.</p>
   <p><b>Performance highlights include the following:</b></p>
   <ul>
-    <li>POWER11 CPU recognition and exploitation are added to achieve optimal performance on new hardware.</li>
+    <li>The performance of operations that involve the Unsafe APIs are improved across platforms.</li>
+    <li>The performance of long running methods that are called infrequently are improved by ensuring that JIT compilations for such methods that end up with a large number of bytecodes finish quickly.</li>
   </ul>
   </div>
 </div>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/371

Updated latest release section for 0.51.0 in website.

Closes #371
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>