### PR TITLE
Update latest release section for 0.54.0 in website

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,33 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 <div class="w3-padding-64 w3-container w3-light-grey">
   <div class="w3-content">
         <div class="w3-center">
+      <h1>Eclipse OpenJ9 version 0.54.0 released</h1>
+<p>August 2025</p>
+</div>
+<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.54.0.</p>
+<p>This release supports OpenJDK 24. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
+<p>Other updates in this release include the following:</p>
+ <ul>
+    <li>The following new JDK Flight Recorder (JFR) events are added in this release:
+      <ul>
+      <li>ModuleExports</li>
+      <li>ModuleRequires</li>
+      </ul>
+    </li>
+</ul>   
+  <p>To read more about these and other changes, see the <a class="w3-hover-opacity" href="https://www.eclipse.org/openj9/docs/openj9_releases/" target="_blank">OpenJ9 user documentation</a>.</p>
+  <p><b>Performance highlights include the following:</b></p>
+
+   <ul>
+      <li>More Java Class Library intrinsics are being accelerated now across platforms.</li>
+      </ul>
+  
+  </div>
+</div>
+
+<div class="w3-padding-64 w3-container w3-light-grey">
+  <div class="w3-content">
+        <div class="w3-center">
       <h1>Eclipse OpenJ9 version 0.53.0 released</h1>
 <p>July 2025</p>
 </div>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/373

Updated latest release section for 0.54.0 in website.

Closes #373
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>