### PR TITLE
Update latest release section for 0.60.0 in website

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,32 +119,27 @@ body,h1,h2,h3,h4,h5,h6 {font-family: "Lato", sans-serif}
 <div class="w3-padding-64 w3-container w3-light-grey">
   <div class="w3-content">
         <div class="w3-center">
-      <h1 id="news">Eclipse OpenJ9 version 0.59.0 released</h1>
-<p>April 2026</p>
+      <h1 id="news">Eclipse OpenJ9 version 0.60.0 released</h1>
+<p>July 2026</p>
 </div>
-<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.59.0.</p>
+<p>We're pleased to announce the availability of Eclipse OpenJ9 v0.60.0.</p>
 <p>This release supports OpenJDK 8, 11, 17, 21, 25, and 26. For more information about supported platforms and OpenJDK versions, see <a class="w3-hover-opacity" href="https://eclipse.dev/openj9/docs/openj9_support/" target="_blank">Supported environments</a>.</p>
 <p>Other updates in this release include the following:</p>
  <ul>
-  <li>The new <code>-XX:[+|-]UseMediumPageSize</code> option is added to enable or disable the default setting of the <code>LDR_CNTRL</code> environment variable on AIX systems whereby medium page sizes (64 KB) are configured for text, data, stack, and shared memory segments.</li>
-<li>A signal handler optimization feature that was temporarily disabled on Windows in the 0.57.0 release is enabled again.</li>
-<li>Linux&reg; x86 64-bit, Linux on POWER&reg; LE 64-bit, and Linux on IBM Z&reg; 64-bit builds on all OpenJDK versions now use gcc 14.2 compiler.</li>
-<li>For OpenJDK versions 8 and 11, Linux x86 64-bit is now compiled on CentOS 7 and RHEL 7, modifying the minimum glibc version to 2.17 from 2.12. The VM will fail to start on CentOS 6 and RHEL 6 from this release onwards.</li>
-<li>The <code>-XX:StartFlightRecording</code> command-line option is added to start the JDK Flight Recorder (JFR) recording in the VM.</li>
+  <li>The <code>-Xcheck:dump</code> option is enhanced on z/OS systems to validate dataset names that are specified in <code>-Xdump:system</code> options and detects improper VM options. This validation prevents deployment of misconfigured applications and ensures that your diagnostic dumps will be created successfully and will not fail because of invalid dataset names.</li>
+<li>Linux AArch64 64-bit builds on all OpenJDK versions now use the gcc 14.2 compiler.</li>
 <li>The following new JFR events are added in this release:
-  <ul><li>GarbageCollection</li>
-<li>OldGarbageCollection</li>
-<li>YoungGarbageCollection</li></ul>
-</li>
-<li>When <code>jcmd Dump.heap</code> is used to request a heap dump, the <code>compact</code> option is added to the dump request by default. The default request for heap dumps is now: <code>request=exclusive+compact+prepwalk</code>.</li>
+<ul><li>GCHeapSummary</li>
+<li>NetworkUtilization></li></ul></li>
+<li>RHEL 9.4 is out of Extended Update Support (EUS). RHEL 9.6 is the new minimum operating system level.</li>
+<li>New parameter <code>footprint</code> is added to the <code>-Xtune</code> command-line option. This option is used to optimize Eclipse OpenJ9 VM function by minimizing OpenJ9 VM memory usage.</li>
 </ul>
   <p>To read more about these and other changes, see the <a class="w3-hover-opacity" href="https://eclipse.dev/openj9/docs/openj9_releases/" target="_blank">OpenJ9 user documentation</a>.</p>
   
   <p><b>Performance highlights include the following:</b></p>
 
    <ul>
-      <li>The performance of multidimensional array allocation is improved across platforms.</li>
-      <li>Incremental improvements in the performance of Java Class Library methods and interface method dispatch sequences.</li>
+      <li>Performance of Java method handles improved in general, and specifically when the <code>MemorySegment</code> class is used.</li>
     </ul>
   
   </div>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-website/issues/379

Updated latest release section for 0.60.0 in website.

Closes #379
Signed-off-by: Sreekala Gopakumar <sreekala.gopakumar@ibm.com>